### PR TITLE
[Add] ユーザーごとに復習時間を設定でき、復習予定日を決定する処理を追加

### DIFF
--- a/app/controllers/subject_details_controller.rb
+++ b/app/controllers/subject_details_controller.rb
@@ -17,8 +17,14 @@ class SubjectDetailsController < ApplicationController
     @subject_detail = SubjectDetail.new(subject_detail_params)
     if @subject_detail.save
 
+      # ユーザーの復習日数設定を取得
+      review_days = []
+      4.times do |i|
+        review_days.push(current_user.user_review_settings.where(review_number: i + 1).first.review_days)
+      end
+
       # ここで、subject_reviewを作成する
-      SubjectReview.create_revies(@subject_detail)
+      SubjectReview.create_reviews(@subject_detail, review_days)
 
       redirect_to subject_subject_details_path(@subject.id), success: t('.success')
     else
@@ -30,7 +36,7 @@ class SubjectDetailsController < ApplicationController
   def edit; end
 
   def update
-    if @subject_detail.update(subject_detail_update_params)
+    if @subject_detail.update(update_subject_detail_params)
       redirect_to subject_subject_details_path(@subject_detail.subject_id), success: t('.success')
     else
       flash.now[:danger] = t('.fail')
@@ -50,7 +56,7 @@ class SubjectDetailsController < ApplicationController
 
   def update_review_time
     # binding.break
-    if @subject_detail.update(subject_review_update_params)
+    if @subject_detail.update(update_subject_review_params)
       redirect_to subject_subject_details_path(@subject_detail.subject_id), success: t('.success')
     else
       flash.now[:danger] = t('.fail')
@@ -83,11 +89,11 @@ class SubjectDetailsController < ApplicationController
     params.require(:subject_detail).permit(:chapter, :start_page, :end_page, :start_at).merge(subject_id: params[:subject_id])
   end
 
-  def subject_detail_update_params
+  def update_subject_detail_params
     params.require(:subject_detail).permit(:chapter, :start_page, :end_page, :start_at)
   end
 
-  def subject_review_update_params
+  def update_subject_review_params
     params.require(:subject_detail).permit(subject_reviews_attributes: [:id, :review_at])
     # params.require(:subject_detail).permit(subject_reviews_attributes: [:id, :review_type, :review_number, :review_at])
   end

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -1,0 +1,28 @@
+class UserSettingsController < ApplicationController
+  before_action :set_user, only: %i[edit update]
+
+  def edit
+    @user_review_settings = @user.user_review_settings.order(:review_number)
+  end
+
+  def update
+    if @user.update(update_user_review_setting_params)
+      flash.now[:success] = t('.success')
+      render :edit, status: :unprocessable_entity
+    else
+      flash.now[:danger] = t('.fail')
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = current_user
+  end
+
+  def update_user_review_setting_params
+    params.require(:user).permit(user_review_settings_attributes: [:id, :review_days])
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+
+      # ここで、user_review_settingを作成する
+      UserReviewSetting.create_review_days(@user)
+
       redirect_to login_path, success: t('.success')
     else
       flash.now[:danger] = t('.fail')

--- a/app/helpers/user_settings_helper.rb
+++ b/app/helpers/user_settings_helper.rb
@@ -1,0 +1,2 @@
+module UserSettingsHelper
+end

--- a/app/models/subject_review.rb
+++ b/app/models/subject_review.rb
@@ -7,15 +7,15 @@ class SubjectReview < ApplicationRecord
   enum review_type: { plan: 0, actual: 1 }
 
 
-  def self.create_revies(subject_detail)
+  def self.create_reviews(subject_detail, review_days)
+
     2.times do |i|
       4.times do |j|
-        @subject_review = SubjectReview.new
-        @subject_review.subject_detail_id = subject_detail.id
-        @subject_review.review_type = i
-        @subject_review.review_number = j + 1
-        i == 0 ? @subject_review.review_at = Date.today + (j + 1).days : nil
-        @subject_review.save!
+        subject_review = subject_detail.subject_reviews.build
+        subject_review.review_type = i
+        subject_review.review_number = j + 1
+        i == 0 ? subject_review.review_at = subject_detail.start_at + review_days[j].days : nil
+        subject_review.save!
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   has_many :subjects, dependent: :destroy
+  has_many :user_review_settings, dependent: :destroy
+  accepts_nested_attributes_for :user_review_settings
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user_review_setting.rb
+++ b/app/models/user_review_setting.rb
@@ -1,0 +1,16 @@
+class UserReviewSetting < ApplicationRecord
+  belongs_to :user
+
+  validates :review_number, presence: true
+  validates :review_days, presence: true
+
+  def self.create_review_days(user)
+    4.times do |j|
+      user_review_setting = user.user_review_settings.build
+      user_review_setting.review_number = j + 1
+      user_review_setting.review_days = j + 1 + 5
+      user_review_setting.save!
+    end
+  end
+
+end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -30,7 +30,7 @@
           </a>
           <div class="dropdown-menu dropdown-menu-lg-end">
             <%= link_to 'プロフィール', '#', class: 'dropdown-item' %>
-            <%= link_to '設定', '#', class: 'dropdown-item' %>
+            <%= link_to t('defaults.setting'), user_setting_users_path, class: 'dropdown-item' %>
             <%= link_to t('defaults.logout'), logout_path, class: 'dropdown-item', data: { turbo_method: :delete, turbo_confirm: t('defaults.message.confirm_logout') } %>
           </div>
         </li>

--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -1,0 +1,42 @@
+<% content_for(:title, t('.title')) %>
+<section class="section-padding">
+  <div class="container">
+    <div class="row">
+      <div class="col-6 mx-auto">
+        <h3 class="title-text text-center"><%= t('.title') %></h3>
+        <div class="tab-content shadow-lg">
+          <%= form_with model: @user, url: update_user_setting_users_path do |f| %>
+
+            <span class="label-text"><%= t('.user_review_settings_title') %></span>
+
+            <%= f.fields_for :user_review_settings, @user_review_settings do |s_f| %>
+              <%= render 'shared/error_messages', object: s_f.object %>
+
+                <div class="form-group mb-3">
+                  <div class="row d-flex align-items-center">
+                    <div class="col-1">
+                    </div>
+                    <div class="col-2">
+                      <%= "#{s_f.object.review_number}#{t('.review_number_label')}" %>
+                    </div>
+                    <div class="col-2">
+                      <%= s_f.number_field  :review_days, class: 'form-control', min: "1", max: "99" %>
+                    </div>
+                    <div class="col-2">
+                      <%= t('.review_days_label') %>
+                    </div>
+                  </div>
+                </div>
+            <% end %>
+
+            <div class="text-center mb-3">
+              <%= f.submit t('defaults.register'), class: 'btn custom-btn btn-wide' %>
+            </div>
+
+          <% end %>
+        </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,6 +5,7 @@ ja:
       subject: '科目'
       subject_detail: '科目詳細'
       subject_review: '復習時間'
+      user_review_setting: '復習設定'
     attributes:
       user:
         email: 'メールアドレス'
@@ -13,6 +14,9 @@ ja:
         last_name: '姓'
         first_name: '名'
         full_name: '氏名'
+      user_review_setting:
+        review_number: '復習回数'
+        review_days: '復習日数'
       subject:
         title: 'タイトル'
         start_at: '学習開始日時'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,6 +10,7 @@ ja:
     delete: '削除'
     detail: '詳細'
     menu: 'メニュー'
+    setting: '設定'
     message:
       require_login: 'ログインしてください'
       confirm_logout: 'ログアウトしますか？'
@@ -31,6 +32,15 @@ ja:
       fail: 'ログインに失敗しました'
     destroy:
       success: 'ログアウトしました'
+  user_settings:
+    edit:
+      title: '設定'
+      user_review_settings_title: '復習期間'
+      review_number_label: '回目'
+      review_days_label: '日後'
+    update:
+      success: 'ユーザー設定を更新しました'
+      fail: 'ユーザー設定更新に失敗しました'
   subjects:
     index:
       title: '科目一覧'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,12 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
-  resources :users, only: %i[new create]
+  resources :users, only: %i[new create] do
+    collection do
+      get 'user_setting', to: 'user_settings#edit'
+      patch 'update_user_setting', to: 'user_settings#update'
+    end
+  end
   resources :subjects, only: %i[new create index edit update destroy] do
     resources :subject_details, only: %i[new create index edit update destroy], shallow: true do
     # resources :subject_details, only: %i[edit update destroy], shallow: true

--- a/db/migrate/20230505082037_create_user_review_settings.rb
+++ b/db/migrate/20230505082037_create_user_review_settings.rb
@@ -1,0 +1,11 @@
+class CreateUserReviewSettings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_review_settings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :review_number, null: false
+      t.integer :review_days, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_23_022723) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_05_082037) do
   create_table "subject_details", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "subject_id", null: false
     t.string "chapter"
@@ -43,6 +43,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_23_022723) do
     t.index ["user_id"], name: "index_subjects_on_user_id"
   end
 
+  create_table "user_review_settings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "review_number", null: false
+    t.integer "review_days", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_review_settings_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", null: false
     t.string "first_name", null: false
@@ -58,4 +67,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_23_022723) do
   add_foreign_key "subject_details", "subjects"
   add_foreign_key "subject_reviews", "subject_details"
   add_foreign_key "subjects", "users"
+  add_foreign_key "user_review_settings", "users"
 end


### PR DESCRIPTION
ユーザーごとに復習時間を設定できる画面を追加。
科目詳細を作成した際、ユーザーの設定した復習時間から復習予定日を決定する処理を追加