### PR TITLE
[Fix] 復習日数に0 を設定できるように変更

### DIFF
--- a/app/models/subject_review.rb
+++ b/app/models/subject_review.rb
@@ -13,7 +13,7 @@ class SubjectReview < ApplicationRecord
         subject_review = subject_detail.subject_reviews.build
         subject_review.review_type = i
         subject_review.review_number = j + 1
-        i == 0 ? subject_review.review_at = subject_detail.start_at + review_days[j].days : nil
+        i == 0 && review_days[j].days != 0 ? subject_review.review_at = subject_detail.start_at + review_days[j].days : nil
         subject_review.save!
       end
     end

--- a/app/views/admin/system_review_settings/index.html.erb
+++ b/app/views/admin/system_review_settings/index.html.erb
@@ -11,7 +11,7 @@
               <%= "#{system_review_setting.review_number}#{t('.review_number_label')}" %>
             </th>
             <td>
-              <%= f.number_field "system_review_setting[#{system_review_setting.id}][review_days]", value: system_review_setting.review_days, class: 'form-control d-inline w-50', min: "1", max: "99" %>
+              <%= f.number_field "system_review_setting[#{system_review_setting.id}][review_days]", value: system_review_setting.review_days, class: 'form-control d-inline w-50', min: "0", max: "99" %>
               <%= t('.review_days_label') %>
             </td>
             <td>

--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -8,6 +8,7 @@
           <%= form_with model: @user, url: update_user_setting_users_path do |f| %>
 
             <p class="label-text required mb-2"><%= t('.user_review_settings_title') %></p>
+            <p><%= t('.review_days_attention') %></p>
 
             <%= f.fields_for :user_review_settings, @user_review_settings do |s_f| %>
               <%= render 'shared/error_messages', object: s_f.object %>
@@ -20,7 +21,7 @@
                     <%= "#{s_f.object.review_number}#{t('.review_number_label')}" %>
                   </div>
                   <div class="col-3">
-                    <%= s_f.number_field :review_days, class: 'form-control', min: "1", max: "99", placeholder: t('.placeholder.review_days') %>
+                    <%= s_f.number_field :review_days, class: 'form-control', min: "0", max: "99", placeholder: t('.placeholder.review_days') %>
                   </div>
                   <div class="col-3">
                     <%= t('.review_days_label') %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -60,6 +60,7 @@ ja:
     edit:
       title: '設定'
       user_review_settings_title: '復習期間'
+      review_days_attention: '※日数を設定しない場合は 0 を入力してください。'
       review_number_label: '回目'
       review_days_label: '日後'
       user_remind_settings_title: 'リマインド通知'


### PR DESCRIPTION
復習日数に0 を設定できるように変更（復習日を設定しない場合に0を設定する）
以下を修正
- ユーザー設定画面
- 管理者用システム復習設定画面
- 復習時間作成処理